### PR TITLE
refactor: Update Firebase dependencies and enhance error reporting

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
             implementation(project.dependencies.platform(libs.firebase.bom))
-            implementation(libs.firebase.crashlytics.ktx)
-            implementation(libs.firebase.config.ktx)
+            implementation(libs.firebase.crashlytics)
+            implementation(libs.firebase.config)
             implementation(libs.firebase.perf)
         }
         commonMain.dependencies {

--- a/core/common/src/androidMain/kotlin/br/com/ricarlo/common/CrashlyticsProvider.android.kt
+++ b/core/common/src/androidMain/kotlin/br/com/ricarlo/common/CrashlyticsProvider.android.kt
@@ -41,7 +41,7 @@ internal class CrashlyticsProviderImpl(
                 is String -> crashlytics.setCustomKey(key, value)
                 else -> crashlytics.recordException(
                     IllegalArgumentException(
-                        "Unsupported type: ${value.javaClass.name} setting custom key $key with value $value"
+                        "Unsupported type: ${value.javaClass.name} for key $key with value $value"
                     )
                 )
             }

--- a/core/common/src/androidMain/kotlin/br/com/ricarlo/common/CrashlyticsProvider.android.kt
+++ b/core/common/src/androidMain/kotlin/br/com/ricarlo/common/CrashlyticsProvider.android.kt
@@ -39,7 +39,11 @@ internal class CrashlyticsProviderImpl(
                 is Int -> crashlytics.setCustomKey(key, value)
                 is Long -> crashlytics.setCustomKey(key, value)
                 is String -> crashlytics.setCustomKey(key, value)
-                else -> crashlytics.log("Error setting custom key $key with value $value")
+                else -> crashlytics.recordException(
+                    IllegalArgumentException(
+                        "Unsupported type: ${value.javaClass.name} setting custom key $key with value $value"
+                    )
+                )
             }
         }
     }

--- a/core/common/src/androidMain/kotlin/br/com/ricarlo/common/RemoteConfigProvider.android.kt
+++ b/core/common/src/androidMain/kotlin/br/com/ricarlo/common/RemoteConfigProvider.android.kt
@@ -1,6 +1,7 @@
 package br.com.ricarlo.common
 
 import com.google.firebase.Firebase
+import com.google.firebase.FirebaseException
 import com.google.firebase.remoteconfig.ConfigUpdate
 import com.google.firebase.remoteconfig.ConfigUpdateListener
 import com.google.firebase.remoteconfig.CustomSignals
@@ -35,7 +36,7 @@ internal class RemoteConfigProviderImpl(
                 }
 
                 override fun onError(p0: FirebaseRemoteConfigException) {
-                    crashlytics.log("Error listening for config updates: ${p0.message}")
+                    crashlytics.recordException(FirebaseException("Error listening for config updates: ${p0.message}"))
                 }
             })
         }
@@ -68,7 +69,7 @@ internal class RemoteConfigProviderImpl(
                         is Int -> put(key, value.toLong())
                         is Float -> put(key, value.toDouble())
                         else -> crashlytics.recordException(
-                            IllegalArgumentException("Unsupported type: ${value.javaClass.name} setting custom key $key with value $value")
+                            IllegalArgumentException("Unsupported type: ${value.javaClass.name} for key $key with value $value")
                         )
                     }
                 }

--- a/core/common/src/androidMain/kotlin/br/com/ricarlo/common/RemoteConfigProvider.android.kt
+++ b/core/common/src/androidMain/kotlin/br/com/ricarlo/common/RemoteConfigProvider.android.kt
@@ -1,13 +1,13 @@
 package br.com.ricarlo.common
 
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.Firebase
 import com.google.firebase.remoteconfig.ConfigUpdate
 import com.google.firebase.remoteconfig.ConfigUpdateListener
 import com.google.firebase.remoteconfig.CustomSignals
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigException
-import com.google.firebase.remoteconfig.ktx.remoteConfig
-import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
+import com.google.firebase.remoteconfig.remoteConfig
+import com.google.firebase.remoteconfig.remoteConfigSettings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
@@ -68,7 +68,7 @@ internal class RemoteConfigProviderImpl(
                         is Int -> put(key, value.toLong())
                         is Float -> put(key, value.toDouble())
                         else -> crashlytics.recordException(
-                            IllegalArgumentException("Unsupported type: ${value.javaClass.name}")
+                            IllegalArgumentException("Unsupported type: ${value.javaClass.name} setting custom key $key with value $value")
                         )
                     }
                 }

--- a/core/notification/build.gradle.kts
+++ b/core/notification/build.gradle.kts
@@ -11,8 +11,8 @@ kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(project.dependencies.platform(libs.firebase.bom))
-            implementation(libs.firebase.messaging.ktx)
-            implementation(libs.firebase.analytics.ktx)
+            implementation(libs.firebase.messaging)
+            implementation(libs.firebase.analytics)
         }
         commonMain.dependencies {
             implementation(projects.core.common)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,11 +21,11 @@ compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = 
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junit" }
 
-firebase-bom = { module = "com.google.firebase:firebase-bom", version = "33.16.0" }
-firebase-analytics-ktx = { module = "com.google.firebase:firebase-analytics-ktx" }
-firebase-messaging-ktx = { module = "com.google.firebase:firebase-messaging-ktx" }
-firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics-ktx" }
-firebase-config-ktx = { module = "com.google.firebase:firebase-config-ktx" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version = "34.3.0" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
+firebase-config = { module = "com.google.firebase:firebase-config" }
 firebase-perf = { module = "com.google.firebase:firebase-perf" }
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }

--- a/iosApp/iosApp/CrashlyticsProviderImpl.swift
+++ b/iosApp/iosApp/CrashlyticsProviderImpl.swift
@@ -1,7 +1,4 @@
 //
-//  CrashlyticsLoggerImpl.swift
-//  iosApp
-//
 //  Created by Ricarlo Silva on 17/07/25.
 //  Copyright © 2025 orgName. All rights reserved.
 //

--- a/iosApp/iosApp/RemoteConfigProviderImpl.swift
+++ b/iosApp/iosApp/RemoteConfigProviderImpl.swift
@@ -102,7 +102,7 @@ internal class RemoteConfigProviderImpl: RemoteConfigProvider {
                 default:
                     crashlytics.recordException(
                         throwable: KotlinThrowable(
-                            message: "Unhandled custom signal type for key \(key): \(value.class)"
+                            message: "Unsupported custom signal type for key \(key) with value \(value)"
                         )
                     )
                 }

--- a/iosApp/iosApp/RemoteConfigProviderImpl.swift
+++ b/iosApp/iosApp/RemoteConfigProviderImpl.swift
@@ -102,7 +102,7 @@ internal class RemoteConfigProviderImpl: RemoteConfigProvider {
                 default:
                     crashlytics.recordException(
                         throwable: KotlinThrowable(
-                            message: "Unhandled custom signal type"
+                            message: "Unhandled custom signal type for key \(key): \(value.class)"
                         )
                     )
                 }

--- a/iosApp/iosApp/RemoteConfigProviderImpl.swift
+++ b/iosApp/iosApp/RemoteConfigProviderImpl.swift
@@ -24,18 +24,22 @@ internal class RemoteConfigProviderImpl: RemoteConfigProvider {
         remoteConfig.setDefaults(defaults)
         remoteConfig.addOnConfigUpdateListener { configUpdate, error in
             guard let configUpdate, error == nil else {
-                return self.crashlytics.log(
-                    message:
-                        "Error listening for config updates: \(String(describing: error))"
+                return self.crashlytics.recordException(
+                    throwable: KotlinThrowable(
+                        message:
+                            "Error listening for config updates: \(String(describing: error))"
+                    )
                 )
             }
 
             if !configUpdate.updatedKeys.isEmpty {
                 self.remoteConfig.activate { changed, error in
                     guard error == nil else {
-                        return self.crashlytics.log(
-                            message:
-                                "Error activate config: \(String(describing:error))"
+                        return self.crashlytics.recordException(
+                            throwable: KotlinThrowable(
+                                message:
+                                    "Error activate config: \(String(describing:error))"
+                            )
                         )
                     }
                 }
@@ -51,9 +55,11 @@ internal class RemoteConfigProviderImpl: RemoteConfigProvider {
             do {
                 try await remoteConfig.fetchAndActivate()
             } catch {
-                crashlytics.log(
-                    message:
-                        "Error fetching remote config: \(error.localizedDescription)"
+                crashlytics.recordException(
+                    throwable: KotlinThrowable(
+                        message:
+                            "Error fetching remote config: \(error.localizedDescription)"
+                    )
                 )
             }
         }
@@ -93,16 +99,23 @@ internal class RemoteConfigProviderImpl: RemoteConfigProvider {
                     custom[key] = .double(dbl)
                 case let flt as Float:
                     custom[key] = .double(Double(flt))
-                default: continue
+                default:
+                    crashlytics.recordException(
+                        throwable: KotlinThrowable(
+                            message: "Unhandled custom signal type"
+                        )
+                    )
                 }
             }
 
             do {
                 try await remoteConfig.setCustomSignals(custom)
             } catch {
-                crashlytics.log(
-                    message:
-                        "Failed to setCustomSignals: \(error.localizedDescription)"
+                crashlytics.recordException(
+                    throwable: KotlinThrowable(
+                        message:
+                            "Failed to setCustomSignals: \(error.localizedDescription)"
+                    )
                 )
             }
         }


### PR DESCRIPTION
This commit updates Firebase dependencies to use the non-KTX versions and improves error reporting for unsupported types in Crashlytics and Remote Config.

**Key Changes:**

- **Firebase Dependencies (`gradle/libs.versions.toml`, `core/common/build.gradle.kts`, `core/notification/build.gradle.kts`):**
    - Updated Firebase BOM to version `34.3.0`.
    - Switched from KTX versions of Firebase libraries to their non-KTX counterparts:
        - `firebase-crashlytics-ktx` -> `firebase-crashlytics`
        - `firebase-config-ktx` -> `firebase-config`
        - `firebase-messaging-ktx` -> `firebase-messaging`
        - `firebase-analytics-ktx` -> `firebase-analytics`
    - Adjusted imports in `core/common/src/androidMain/kotlin/br/com/ricarlo/common/RemoteConfigProvider.android.kt` accordingly.
- **Error Reporting (`CrashlyticsProvider.android.kt`, `RemoteConfigProvider.android.kt`, `RemoteConfigProviderImpl.swift`):**
    - **Android:**
        - In `CrashlyticsProvider.android.kt`, when setting a custom key with an unsupported value type, an `IllegalArgumentException` is now recorded in Crashlytics instead of just logging a message. The exception message includes the key and value.
        - In `RemoteConfigProvider.android.kt`, when an unsupported type is encountered while setting custom signals, an `IllegalArgumentException` is recorded in Crashlytics with details about the key and value.
    - **iOS:**
        - In `RemoteConfigProviderImpl.swift`, errors during `fetchAndActivate()` and `setCustomSignals()` are now reported to Crashlytics as exceptions using `crashlytics.recordException`.
        - When an unhandled custom signal type is encountered, a `KotlinThrowable` with the message "Unhandled custom signal type" is recorded.
- **Cleanup (`iosApp/iosApp/CrashlyticsProviderImpl.swift`):**
    - Removed commented-out file header.